### PR TITLE
Possible fix to intermittent CI failure

### DIFF
--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -8,3 +8,4 @@ set -eo pipefail
 apt update --yes --quiet
 apt upgrade --yes --quiet
 apt install --yes --quiet ccache cmake lcov python3-pip
+ccache --show-stats


### PR DESCRIPTION
- in clang-tidy-clang CI job
- "ccache: error: /root/.ccache/ccache.conf: No such file or directory"
- intend that invoking ccache in order to create this file will ensure that
  it's there when it needs to be