### PR TITLE
Move ccache pre-build status output to later job

### DIFF
--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -8,4 +8,3 @@ set -eo pipefail
 apt update --yes --quiet
 apt upgrade --yes --quiet
 apt install --yes --quiet ccache cmake python3-pip "$@"
-ccache --show-stats

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,6 +6,8 @@ set -eo pipefail
 
 PROJECT_DIR=$(cd "$(dirname "$0")"/..; pwd)
 
+ccache --show-stats
+
 "${PROJECT_DIR}/scripts/bits/init.sh"
 
 "${PROJECT_DIR}/scripts/bits/config.sh" \
@@ -13,3 +15,5 @@ PROJECT_DIR=$(cd "$(dirname "$0")"/..; pwd)
   -DCMAKE_CXX_FLAGS_RELEASE="-DGSL_UNENFORCED_ON_CONTRACT_VIOLATION"
 
 "${PROJECT_DIR}/scripts/bits/build.sh"
+
+ccache --show-stats


### PR DESCRIPTION
- was being run before ccache was downloaded
- also called after build