### PR TITLE
Make it easier to initialize conan w. multiple compilers

### DIFF
--- a/scripts/bits/init.sh
+++ b/scripts/bits/init.sh
@@ -8,7 +8,9 @@ PROJECT_DIR=$(cd "$(dirname "$0")"/../..; pwd)
 
 pip3 install --quiet conan
 conan remote add --force my-conan-repo https://api.bintray.com/conan/bincrafters/public-conan
-conan profile new ./conan-profile --detect --force
+if [[ ! -f ./conan-profile ]]; then
+  conan profile new ./conan-profile --detect
+fi
 conan install \
   --build=missing "${PROJECT_DIR}" \
   --profile=./conan-profile


### PR DESCRIPTION
- allow user to fix conan-profile file after Conan has chosen the wrong
  compile
- hacky but works