### PR TITLE
Improve readability of approval test output

### DIFF
--- a/scripts/bits/run-approval-test.sh
+++ b/scripts/bits/run-approval-test.sh
@@ -6,16 +6,17 @@ set -eo pipefail
 
 PROJECT_DIR=$(cd "$(dirname "$0")"/../..; pwd)
 TEST=$1
-
-echo testing "$TEST"...
 TEST_DIR="$(dirname "$TEST")"
+RELATIVE_PATH=$(realpath "$TEST_DIR" --relative-to "$PROJECT_DIR")
+
+echo testing "$RELATIVE_PATH" ...
 
 set +e
-stdbuf -o0 "${TEST}" "${PROJECT_DIR}" | \
+"${TEST}" "${PROJECT_DIR}" | \
    diff "${TEST_DIR}/expected.stdout" - 
 
 if [[ $? -ne 0 ]] ; then
-  printf "\033[0;31mFAILED\033[0m\n"
+  printf "\033[0;31mFAILED\033[0m %s\n" "$RELATIVE_PATH"
   exit 1
 fi
 

--- a/test/bin/generate/failures/cli-help/test.sh
+++ b/test/bin/generate/failures/cli-help/test.sh
@@ -4,6 +4,6 @@ shift
 
 "$@" ./src/generate/generate --help
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/generate/failures/missing-lexicon/test.sh
+++ b/test/bin/generate/failures/missing-lexicon/test.sh
@@ -4,6 +4,6 @@ shift
 
 "$@" ./src/generate/generate missing_file.txt
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/generate/failures/missing-new-line/test.sh
+++ b/test/bin/generate/failures/missing-new-line/test.sh
@@ -5,6 +5,6 @@ shift
 
 "$@" ./src/generate/generate "${SCRIPT_DIR}"/lexicon.txt
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/play/failures/2char-tile-cell/test.sh
+++ b/test/bin/play/failures/2char-tile-cell/test.sh
@@ -8,6 +8,6 @@ shift
   "${SCRIPT_DIR}/tiles.csv" \
   "${SCRIPT_DIR}/premiums.csv"
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/play/failures/cli-board-size-mismatch/test.sh
+++ b/test/bin/play/failures/cli-board-size-mismatch/test.sh
@@ -8,6 +8,6 @@ shift
   "${SCRIPT_DIR}/tiles.csv" \
   "${SCRIPT_DIR}/premiums.csv"
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/play/failures/cli-empty/test.sh
+++ b/test/bin/play/failures/cli-empty/test.sh
@@ -4,6 +4,6 @@ shift
 
 "$@" ./src/play/play
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/play/failures/cli-help/test.sh
+++ b/test/bin/play/failures/cli-help/test.sh
@@ -4,6 +4,6 @@ shift
 
 "$@" ./src/play/play --help
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/play/failures/cli-no-tiles/test.sh
+++ b/test/bin/play/failures/cli-no-tiles/test.sh
@@ -4,6 +4,6 @@ shift
 
 "$@" ./src/play/play abcd
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/play/failures/cli-parse-error/test.sh
+++ b/test/bin/play/failures/cli-parse-error/test.sh
@@ -4,6 +4,6 @@ shift
 
 "$@" ./src/play/play -rf /usr/bin
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/play/failures/empty-tile-cell/test.sh
+++ b/test/bin/play/failures/empty-tile-cell/test.sh
@@ -8,6 +8,6 @@ shift
   "${SCRIPT_DIR}/tiles.csv" \
   "${SCRIPT_DIR}/premiums.csv"
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/play/failures/missing-board/test.sh
+++ b/test/bin/play/failures/missing-board/test.sh
@@ -8,6 +8,6 @@ shift
   "${SCRIPT_DIR}/tiles.csv" \
   "${SCRIPT_DIR}/irregular.csv"
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/play/failures/non-alpha-tile-cell/test.sh
+++ b/test/bin/play/failures/non-alpha-tile-cell/test.sh
@@ -8,6 +8,6 @@ shift
   "${SCRIPT_DIR}/tiles.csv" \
   "${SCRIPT_DIR}/premiums.csv"
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/play/failures/number-of-fields/test.sh
+++ b/test/bin/play/failures/number-of-fields/test.sh
@@ -8,6 +8,6 @@ shift
   "${SCRIPT_DIR}/tiles.csv" \
   "${SCRIPT_DIR}/irregular.csv"
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/play/failures/unrecognised-field/test.sh
+++ b/test/bin/play/failures/unrecognised-field/test.sh
@@ -8,6 +8,6 @@ shift
   "${SCRIPT_DIR}/tiles.csv" \
   "${SCRIPT_DIR}/irregular.csv"
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/rack/failures/cli-empty/test.sh
+++ b/test/bin/rack/failures/cli-empty/test.sh
@@ -4,6 +4,6 @@ shift
 
 "$@" ./src/rack/rack
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/rack/failures/cli-help/test.sh
+++ b/test/bin/rack/failures/cli-help/test.sh
@@ -4,6 +4,6 @@ shift
 
 "$@" ./src/rack/rack --help
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/rack/failures/cli-parse-error/test.sh
+++ b/test/bin/rack/failures/cli-parse-error/test.sh
@@ -4,6 +4,6 @@ shift
 
 "$@" ./src/rack/rack -rf /usr/bin
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi

--- a/test/bin/rack/failures/cli-too-few-letters/test.sh
+++ b/test/bin/rack/failures/cli-too-few-letters/test.sh
@@ -4,6 +4,6 @@ shift
 
 "$@" ./src/rack/rack z
 
-if [[ $? -eq 0 ]] ; then
+if [[ $? -ne 1 ]] ; then
     exit 1
 fi


### PR DESCRIPTION
- print name of test on failure notification line because
  tests are run in parallel and lines of output may overlap
- don't bother trying to flush stdout; that's probably not the problem
- print project-relative test path