### PR TITLE
Replace GSL Expects

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,6 +10,6 @@ PROJECT_DIR=$(cd "$(dirname "$0")"/..; pwd)
 
 "${PROJECT_DIR}/scripts/bits/config.sh" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CXX_FLAGS_RELEASE="-DGSL_UNENFORCED_ON_CONTRACT_VIOLATION"
+  -DCMAKE_CXX_FLAGS_RELEASE="-DNDEBUG"
 
 "${PROJECT_DIR}/scripts/bits/build.sh"

--- a/scripts/clang-static-analyzer.sh
+++ b/scripts/clang-static-analyzer.sh
@@ -13,7 +13,7 @@ scan-build \
   --status-bugs \
     cmake \
       "${PROJECT_DIR}" \
-      -DCMAKE_CXX_FLAGS="-DGSL_UNENFORCED_ON_CONTRACT_VIOLATION"
+      -DCMAKE_CXX_FLAGS="-DNDEBUG"
 
 scan-build \
   -o scan-build \

--- a/scripts/clang-tidy.sh
+++ b/scripts/clang-tidy.sh
@@ -11,7 +11,7 @@ BITS_DIR=$(cd "$(dirname "$0")"/bits; pwd)
 "${BITS_DIR}/config.sh" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_CLANG_TIDY=clang-tidy \
-  -DCMAKE_CXX_FLAGS_RELEASE="-DGSL_UNENFORCED_ON_CONTRACT_VIOLATION"
+  -DCMAKE_CXX_FLAGS_RELEASE="-DNDEBUG"
 
 "${BITS_DIR}/build.sh"
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -10,7 +10,7 @@ PROJECT_DIR=$(cd "$(dirname "$0")"/.. || exit; pwd)
 
 "${PROJECT_DIR}/scripts/bits/config.sh" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CXX_FLAGS_RELEASE="-coverage -fno-exceptions"
+  -DCMAKE_CXX_FLAGS_RELEASE="-coverage -fno-exceptions -DWSS_DISABLE_ASSERTS"
 
 "${PROJECT_DIR}/scripts/bits/build.sh"
 

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -10,7 +10,7 @@ PROJECT_DIR=$(cd "$(dirname "$0")"/..; pwd)
 
 "${PROJECT_DIR}/scripts/bits/config.sh" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CXX_FLAGS_RELEASE="-g -DGSL_UNENFORCED_ON_CONTRACT_VIOLATION -fno-omit-frame-pointer"
+  -DCMAKE_CXX_FLAGS_RELEASE="-g -DNDEBUG -fno-omit-frame-pointer"
 
 "${PROJECT_DIR}/scripts/bits/build.sh"
 

--- a/scripts/sanitize.sh
+++ b/scripts/sanitize.sh
@@ -13,7 +13,7 @@ export ASAN_OPTIONS=verify_asan_link_order=0
 
 "${BITS_DIR}/config.sh" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CXX_FLAGS_RELEASE="-g -fsanitize=address,undefined -fsanitize-undefined-trap-on-error -DGSL_UNENFORCED_ON_CONTRACT_VIOLATION"
+  -DCMAKE_CXX_FLAGS_RELEASE="-g -fsanitize=address,undefined -fsanitize-undefined-trap-on-error -DNDEBUG"
 
 "${BITS_DIR}/build.sh"
 

--- a/src/common/wss_assert.h
+++ b/src/common/wss_assert.h
@@ -1,0 +1,42 @@
+// Copyright 2020 John McFarlane
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef WSS_ASSERT_H
+#define WSS_ASSERT_H
+
+#include <exception>
+
+// For testing coverage, assertions are not necessarily a concern.
+#if defined(WSS_DISABLE_ASSERTS)
+#define WSS_ASSERT(cond)
+
+// In debug builds, fail fast and loud when an assertion is challenged.
+#elif !defined(NDEBUG)
+#define WSS_ASSERT(cond) ((cond) ? static_cast<void>(0) : std::terminate())
+
+// In optimised GCC builds, optimise/sanitize accordingly.
+#elif defined(__GNUC__)
+#define WSS_ASSERT(cond) ((cond) ? static_cast<void>(0) : __builtin_unreachable())
+
+// In optimised MSVC builds, optimise/sanitize accordingly.
+#elif defined(_MSC_VER)
+#define WSS_ASSERT(cond) __assume(cond)
+
+// In other optimised builds assume code is correct.
+#else
+#define WSS_ASSERT(cond)
+
+#endif
+
+#endif //WSS_ASSERT_H

--- a/src/generate/trie.cpp
+++ b/src/generate/trie.cpp
@@ -15,11 +15,10 @@
 #include "trie.h"
 
 #include <ssize.h>
-
-#include <fmt/printf.h>
-#include <gsl/gsl_assert>
+#include <wss_assert.h>
 
 #include <algorithm>
+#include <fmt/printf.h>
 #include <map>
 
 namespace {
@@ -49,7 +48,7 @@ namespace {
             string_view::const_iterator pos,
             string_view::const_iterator end)
     {
-        Expects(pos<=end);  // LCOV_EXCL_LINE - TODO: unit tests or fix GSL
+        WSS_ASSERT(pos<=end);
 
         if (pos==end) {
             if (n.is_terminator) {
@@ -88,7 +87,7 @@ auto edge::get_next() const -> node const& { return *next; }
 
 void edge::set_next(std::shared_ptr<node> n)
 {
-    Expects(n);  // LCOV_EXCL_LINE - TODO: unit tests or fix GSL
+    WSS_ASSERT(n);
     next = move(n);
 }
 
@@ -115,7 +114,7 @@ auto compress(node& n, node_map& nodes) -> int
 
         auto found{nodes.equal_range(child)};
         if (found.first==found.second) {
-            Expects(edge.ptr());  // LCOV_EXCL_LINE - TODO: unit tests or fix GSL
+            WSS_ASSERT(edge.ptr());
             nodes.emplace_hint(found.first,
                     std::make_pair(edge.get_next(), edge.ptr()));
             continue;

--- a/src/generate/trie.h
+++ b/src/generate/trie.h
@@ -15,8 +15,6 @@
 #ifndef WSS_TRIE_H
 #define WSS_TRIE_H
 
-#include <gsl/gsl_assert>
-
 #include <memory>
 #include <string_view>
 #include <vector>

--- a/src/play/board.h
+++ b/src/play/board.h
@@ -20,6 +20,7 @@
 #include "load_buffer.h"
 
 #include <ssize.h>
+#include <wss_assert.h>
 
 #include <fmt/printf.h>
 #include <gsl/string_span>
@@ -43,23 +44,21 @@ public:
 
     T const& cell(coord c) const
     {
-        // LCOV_EXCL_START
-        Expects(c[0]>=0);
-        Expects(c[0]<edge);
-        Expects(c[1]>=0);
-        Expects(c[1]<edge);
-        // LCOV_EXCL_STOP
+        WSS_ASSERT(c[0]>=0);
+        WSS_ASSERT(c[0]<edge);
+        WSS_ASSERT(c[1]>=0);
+        WSS_ASSERT(c[1]<edge);
+
         return cells.get()[c[0]+c[1]*edge];
     }
 
     T& cell(coord c)
     {
-        // LCOV_EXCL_START
-        Expects(c[0]>=0);
-        Expects(c[0]<edge);
-        Expects(c[1]>=0);
-        Expects(c[1]<edge);
-        // LCOV_EXCL_STOP
+        WSS_ASSERT(c[0]>=0);
+        WSS_ASSERT(c[0]<edge);
+        WSS_ASSERT(c[1]>=0);
+        WSS_ASSERT(c[1]<edge);
+
         return cells.get()[c[0]+c[1]*edge];
     }
 

--- a/src/play/board_premiums.cpp
+++ b/src/play/board_premiums.cpp
@@ -23,13 +23,11 @@ auto load_board_premiums(gsl::cstring_span<> filename)
 -> std::optional<board<premium>>
 {
     std::unordered_map<char, premium> const token_to_premium{
-            // LCOV_EXCL_START - statically defined
             {' ', premium::normal},
             {'d', premium::dl},
             {'t', premium::tl},
             {'D', premium::dw},
             {'T', premium::tw}
-            // LCOV_EXCL_STOP
     };
 
     if (filename.empty()) {

--- a/src/play/solve.cpp
+++ b/src/play/solve.cpp
@@ -20,10 +20,10 @@
 #include "tile.h"
 
 #include <scores.h>
+#include <wss_assert.h>
 #include <wwf_lexicon.h>
 
 #include <fmt/printf.h>
-#include <gsl/gsl_assert>
 #include <gsl/gsl_util>
 
 #include <algorithm>
@@ -116,7 +116,7 @@ namespace {
             int const part_length,
             coord const& cross_direction)
     {
-        Expects((std::abs(cross_direction[0])==1)  // LCOV_EXCL_LINE - TODO: unit tests or fix GSL
+        WSS_ASSERT((std::abs(cross_direction[0])==1)
                 !=(std::abs(cross_direction[1])==1));
 
         auto pre_word_part{-1};
@@ -169,8 +169,8 @@ namespace {
                 word_multiplier *= gsl::at(word_multipliers,
                         int(cell_premium));
 
-                Expects(i>=0);  // LCOV_EXCL_LINE - TODO: unit tests or fix GSL
-                Expects(i<ssize(word_part));  // LCOV_EXCL_LINE - TODO: unit tests or fix GSL
+                WSS_ASSERT(i>=0);
+                WSS_ASSERT(i<ssize(word_part));
                 auto const letter{gsl::at(word_part, i)};
 
                 auto const letter_multiplier{
@@ -220,7 +220,7 @@ namespace {
                     state.init.pos.direction,
                     extents,
                     gsl::span<char>{&*state.init.word, &*state.step.word_end})};
-            Expects(word_score);  // LCOV_EXCL_LINE - TODO: unit tests or fix GSL
+            WSS_ASSERT(word_score);
 
             auto play_score{state.step.cross_scores+*word_score};
             if (state.step.rack_remaining==0
@@ -274,7 +274,7 @@ namespace {
 
     void search(node const& n, search_state state)
     {
-        Expects(state.step.rack_remaining>=0);  // LCOV_EXCL_LINE - TODO: unit tests or fix GSL
+        WSS_ASSERT(state.step.rack_remaining>=0);
 
         auto const qualifying_cells_count{
                 state.init.qualifying_cells.cell(state.step.pos) ? 1 : 0};
@@ -368,14 +368,14 @@ namespace {
     auto make_qualifying_cells(board<char> const& board_tiles) -> board<bool>
     {
         auto const edge{ssize(board_tiles)};
+        WSS_ASSERT(edge>0);
+        
         board<bool> qualifying_cells(edge);
 
-        if (edge>0) {  // LCOV_EXCL_LINE - TODO: unit tests or fix GSL
-            populate_qualifying_cells(qualifying_cells, board_tiles, {-1, 0}, {1, 0}, {edge, edge});
-            populate_qualifying_cells(qualifying_cells, board_tiles, {1, 0}, {0, 0}, {edge-1, edge});
-            populate_qualifying_cells(qualifying_cells, board_tiles, {0, -1}, {0, 1}, {edge, edge});
-            populate_qualifying_cells(qualifying_cells, board_tiles, {0, 1}, {0, 0}, {edge, edge-1});
-        }
+        populate_qualifying_cells(qualifying_cells, board_tiles, {-1, 0}, {1, 0}, {edge, edge});
+        populate_qualifying_cells(qualifying_cells, board_tiles, {1, 0}, {0, 0}, {edge-1, edge});
+        populate_qualifying_cells(qualifying_cells, board_tiles, {0, -1}, {0, 1}, {edge, edge});
+        populate_qualifying_cells(qualifying_cells, board_tiles, {0, 1}, {0, 0}, {edge, edge-1});
 
         qualifying_cells.cell({edge/2, edge/2}) = true;
 


### PR DESCRIPTION
- defines WSS_ASSERT
  - always invokes UB on violate when NDEBUG defined
  - flag, WSS_DISABLE_ASSERTS, ensures branch doesn't affect coverage stats
- removes need for most lcov exceptions; most LCOV annotations removed
- one other branch replaced with an assert