### PR TITLE
Out-of-order lexicon

### DIFF
--- a/src/generate/multi_trie.cpp
+++ b/src/generate/multi_trie.cpp
@@ -26,22 +26,19 @@ namespace {
     using std::end;
     using std::string_view;
 
-    auto find(node::edge_vector& e, char l)
-    {
-        return std::find_if(begin(e), end(e),
-                [l](auto const& edge) { return edge==l; });
-    }
-
     auto insert(int index, node::edge_vector& e, char l) -> node&
     {
-        auto found = find(e, l);
-        if (found!=end(e)) {
-            return found->get_next();
+        auto const [found_first, found_last] = std::equal_range(begin(e), end(e), l);
+
+        auto const num_found = std::distance(found_first, found_last);
+        if (num_found != 0) {
+            WSS_ASSERT(num_found == 1);
+            return found_first->get_next();
         }
 
-        e.emplace_back(l,
-                std::make_unique<node>(node::edge_vector{}, index, false));
-        return e.back().get_next();
+        return e.emplace(found_first, 
+                l,
+                std::make_unique<node>(node::edge_vector{}, index, false))->get_next();
     }
 
     auto insert(

--- a/src/generate/multi_trie.cpp
+++ b/src/generate/multi_trie.cpp
@@ -26,22 +26,22 @@ namespace {
     using std::end;
     using std::string_view;
 
-    auto find(node& n, char l)
+    auto find(node::edge_vector& e, char l)
     {
-        return std::find_if(begin(n.edges), end(n.edges),
+        return std::find_if(begin(e), end(e),
                 [l](auto const& edge) { return edge==l; });
     }
 
-    auto insert(int index, node& n, char l) -> node&
+    auto insert(int index, node::edge_vector& e, char l) -> node&
     {
-        auto found = find(n, l);
-        if (found!=end(n.edges)) {
+        auto found = find(e, l);
+        if (found!=end(e)) {
             return found->get_next();
         }
 
-        n.edges.emplace_back(l,
+        e.emplace_back(l,
                 std::make_unique<node>(node::edge_vector{}, index, false));
-        return n.edges.back().get_next();
+        return e.back().get_next();
     }
 
     auto insert(
@@ -62,7 +62,7 @@ namespace {
             return true;
         }
         auto letter = *pos;
-        auto& next_node = insert(index, n, letter);
+        auto& next_node = insert(index, n.edges, letter);
         return insert(index, next_node, pos+1, end);
     }
 }  // namespace

--- a/test/bin/generate/failures/shuffled-lexicon/expected.txt
+++ b/test/bin/generate/failures/shuffled-lexicon/expected.txt
@@ -1,0 +1,99 @@
+#include "lexicon.h"
+namespace {
+node const nLESS0 = {
+  from_bits(0x1U),
+  nullptr
+};
+node const nLES0e[] {nLESS0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nLES0 = {
+  from_bits(0x80000U),
+  nLES0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nLE0e[] {nLES0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nLE0 = {
+  from_bits(0x80000U),
+  nLE0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nL0e[] {nLE0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nL0 = {
+  from_bits(0x20U),
+  nL0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPA0 = {
+  from_bits(0x100000U),
+  nLES0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTLESSNESS0 = {
+  from_bits(0x20U),
+  nLE0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTLESSNES0e[] {nSPOTLESSNESS0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOTLESSNES0 = {
+  from_bits(0x80000U),
+  nSPOTLESSNES0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTLESSNE0e[] {nSPOTLESSNES0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOTLESSNE0 = {
+  from_bits(0x80000U),
+  nSPOTLESSNE0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTLESSN0e[] {nSPOTLESSNE0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOTLESSN0 = {
+  from_bits(0x20U),
+  nSPOTLESSN0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTLESS0e[] {nSPOTLESSN0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOTLESS0 = {
+  from_bits(0x4000U),
+  nSPOTLESS0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTLES0e[] {nSPOTLESS0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOTLES0 = {
+  from_bits(0x80000U),
+  nSPOTLES0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTLE0e[] {nSPOTLES0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOTLE0 = {
+  from_bits(0x80000U),
+  nSPOTLE0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTL0e[] {nSPOTLE0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOTL0 = {
+  from_bits(0x20U),
+  nSPOTL0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOT0e[] {nSPOTL0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOT0 = {
+  from_bits(0x1000U),
+  nSPOT0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPO0e[] {nSPOT0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPO0 = {
+  from_bits(0x100000U),
+  nSPO0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSP0e[] {nSPA0,nSPO0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSP0 = {
+  from_bits(0x8002U),
+  nSP0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nS0e[] {nSP0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nS0 = {
+  from_bits(0x10000U),
+  nS0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const root_node0e[] {nL0,nS0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const root_node0 = {
+  from_bits(0x81001U),
+  root_node0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const root_node1 = {
+  from_bits(0x81001U),
+  root_node0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+} //namespace
+node const& lexicon{root_node0};
+node const& lexicon{root_node1};
+#include <node.h>
+extern node const& lexicon;
+extern node const& lexicon;

--- a/test/bin/generate/failures/shuffled-lexicon/lexicon.txt
+++ b/test/bin/generate/failures/shuffled-lexicon/lexicon.txt
@@ -1,2 +1,3 @@
 spotlessnesses
-spotlessnesses
+spat
+less

--- a/test/bin/generate/failures/shuffled-lexicon/test.sh
+++ b/test/bin/generate/failures/shuffled-lexicon/test.sh
@@ -9,3 +9,5 @@ shift
   "${SCRIPT_DIR}"/lexicon.txt lexicon \
   "${SCRIPT_DIR}"/lexicon.txt lexicon \
   lexicon
+
+cat lexicon.cpp lexicon.h

--- a/test/bin/generate/happy/expected.txt
+++ b/test/bin/generate/happy/expected.txt
@@ -1,0 +1,99 @@
+#include "lexicon.h"
+namespace {
+node const nLESS0 = {
+  from_bits(0x1U),
+  nullptr
+};
+node const nLES0e[] {nLESS0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nLES0 = {
+  from_bits(0x80000U),
+  nLES0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nLE0e[] {nLES0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nLE0 = {
+  from_bits(0x80000U),
+  nLE0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nL0e[] {nLE0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nL0 = {
+  from_bits(0x20U),
+  nL0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPA0 = {
+  from_bits(0x100000U),
+  nLES0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTLESSNESS0 = {
+  from_bits(0x20U),
+  nLE0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTLESSNES0e[] {nSPOTLESSNESS0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOTLESSNES0 = {
+  from_bits(0x80000U),
+  nSPOTLESSNES0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTLESSNE0e[] {nSPOTLESSNES0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOTLESSNE0 = {
+  from_bits(0x80000U),
+  nSPOTLESSNE0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTLESSN0e[] {nSPOTLESSNE0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOTLESSN0 = {
+  from_bits(0x20U),
+  nSPOTLESSN0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTLESS0e[] {nSPOTLESSN0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOTLESS0 = {
+  from_bits(0x4000U),
+  nSPOTLESS0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTLES0e[] {nSPOTLESS0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOTLES0 = {
+  from_bits(0x80000U),
+  nSPOTLES0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTLE0e[] {nSPOTLES0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOTLE0 = {
+  from_bits(0x80000U),
+  nSPOTLE0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOTL0e[] {nSPOTLE0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOTL0 = {
+  from_bits(0x20U),
+  nSPOTL0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPOT0e[] {nSPOTL0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPOT0 = {
+  from_bits(0x1000U),
+  nSPOT0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSPO0e[] {nSPOT0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSPO0 = {
+  from_bits(0x100000U),
+  nSPO0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nSP0e[] {nSPA0,nSPO0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nSP0 = {
+  from_bits(0x8002U),
+  nSP0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const nS0e[] {nSP0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const nS0 = {
+  from_bits(0x10000U),
+  nS0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const root_node0e[] {nL0,nS0}; //NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+node const root_node0 = {
+  from_bits(0x81001U),
+  root_node0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+node const root_node1 = {
+  from_bits(0x81001U),
+  root_node0e //NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+};
+} //namespace
+node const& lexicon{root_node0};
+node const& lexicon{root_node1};
+#include <node.h>
+extern node const& lexicon;
+extern node const& lexicon;

--- a/test/bin/generate/happy/lexicon.txt
+++ b/test/bin/generate/happy/lexicon.txt
@@ -1,0 +1,3 @@
+less
+spat
+spotlessnesses

--- a/test/bin/generate/happy/test.sh
+++ b/test/bin/generate/happy/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+shift
+
+"$@" ./src/generate/generate \
+  "${SCRIPT_DIR}"/lexicon.txt lexicon \
+  "${SCRIPT_DIR}"/lexicon.txt lexicon \
+  lexicon
+
+cat lexicon.cpp lexicon.h


### PR DESCRIPTION
Fixes case where input lexicon, e.g. wwf.txt is not ordered alphabetically. Adds tests to prevent a similar bug happening again.